### PR TITLE
Removing 'sudo' from Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,6 @@ ifndef KMODVER
 KMODVER=$(shell git describe HEAD 2>/dev/null || git rev-parse --short HEAD)
 endif
 
-buildprep:
-	# elfutils-libelf-devel is needed on EL8 systems
-	-sudo yum install -y gcc kernel-{core,devel,modules}-$(KVER) elfutils-libelf-devel
 all:
 	make -C /lib/modules/$(KVER)/build M=$(PWD) EXTRA_CFLAGS=-DKMODVER=\\\"$(KMODVER)\\\" modules
 	gcc -o spkut ./simple-procfs-kmod-userspace-tool.c
@@ -19,8 +16,8 @@ clean:
 	make -C /lib/modules/$(KVER)/build M=$(PWD) clean
 	rm -f spkut
 install:
-	sudo install -v -m 755 spkut /bin/
-	sudo install -v -m 755 -d /lib/modules/$(KVER)/
-	sudo install -v -m 644 simple-kmod.ko        /lib/modules/$(KVER)/simple-kmod.ko
-	sudo install -v -m 644 simple-procfs-kmod.ko /lib/modules/$(KVER)/simple-procfs-kmod.ko
-	sudo depmod -F /lib/modules/$(KVER)/System.map $(KVER)
+	install -v -m 755 spkut /bin/
+	install -v -m 755 -d /lib/modules/$(KVER)/
+	install -v -m 644 simple-kmod.ko        /lib/modules/$(KVER)/simple-kmod.ko
+	install -v -m 644 simple-procfs-kmod.ko /lib/modules/$(KVER)/simple-procfs-kmod.ko
+	depmod -F /lib/modules/$(KVER)/System.map $(KVER)


### PR DESCRIPTION
Sudo was removed from the container that will run those makefile
commands.

Also the container usually runs in privileged mode, therefore, it
doesn't need sudo.

Also removed 'buildprep' Makefile target as there is no need to
re-download all the packages that DTK already contains.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>