### PR TITLE
allow simple-procfs to work with the new procfs api introduced RHEL9 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ KMODVER=$(shell git describe HEAD 2>/dev/null || git rev-parse --short HEAD)
 endif
 
 all:
-	make -C /lib/modules/$(KVER)/build M=$(PWD) EXTRA_CFLAGS=-DKMODVER=\\\"$(KMODVER)\\\" modules
+	make -C /usr/src/kernels/$(KVER)/ M=$(PWD) EXTRA_CFLAGS=-DKMODVER=\\\"$(KMODVER)\\\" modules
 	gcc -o spkut ./simple-procfs-kmod-userspace-tool.c
 clean:
-	make -C /lib/modules/$(KVER)/build M=$(PWD) clean
+	make -C /usr/src/kernels/$(KVER)/ M=$(PWD) clean
 	rm -f spkut
 install:
 	install -v -m 755 spkut /bin/

--- a/simple-procfs-kmod.c
+++ b/simple-procfs-kmod.c
@@ -9,6 +9,7 @@
 #include <linux/kernel.h>   
 #include <linux/proc_fs.h>
 #include <asm/uaccess.h>
+#include <linux/version.h>
 #define BUFSIZE  100
 
 #define PROCFS_NAME "simple-procfs-kmod"
@@ -60,12 +61,27 @@ static ssize_t myread(struct file *file, char __user *ubuf,size_t count, loff_t 
     return len;
 }
 
+// the api for procfs changed with the 5.6 kernel to use the proc_ops struct rather than file_operations
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,6,0)
+static loff_t proc_lseek(struct file *file, loff_t offset, int i)
+{
+    file->f_pos = offset;
+    return offset;
+}
+static struct proc_ops myops =
+{
+    .proc_read = myread,
+    .proc_write = mywrite,
+    .proc_lseek = proc_lseek,
+};
+#else
 static struct file_operations myops = 
 {
     .owner = THIS_MODULE,
     .read = myread,
     .write = mywrite,
 };
+#endif
 
 static int simple_init(void)
 {


### PR DESCRIPTION
kernel commit d56c0d45f0e27f814e87a1676b6bdccccbc252e9 changed the signature of the proc_create() function (used by simple-procfs-kmod.c) from taking an argument of type struct file_operations to taking a new struct, struct proc_ops.  This change seems to have happened in the 5.6 kernel release so was not in RHEL8 but is now part of the RHEL9 kernel.

This causes simple-procfs-kmod.ko to fail to compile under RHEL9 with a message:

_./include/linux/proc_fs.h:110:122: note: expected 'const struct proc_ops *' but argument is of type 'struct file_operations *'
  110 | struct proc_dir_entry *proc_create(const char *name, umode_t mode, struct proc_dir_entry *parent, const struct proc_ops *proc_ops);_
 
This PR updates the code to allocate and populate a (very) basic proc_ops structure using the exisiting myread and mywrite functions, and use that as the argument to proc_create. It also adds a proc_lseek function stub which proc_ops mandates. Without this running the spkut utility causes a kernel panic (due to a null pointer dereference).

It wraps the new code in an #ifdef preprocessor directive that checks for the 5.6 kernel and uses the appropriate version of the code so the kmod will continue to compile on RHEL8 as before, only using the new struct for later kernels.